### PR TITLE
WIP: Serialize binary data

### DIFF
--- a/parsed_json.go
+++ b/parsed_json.go
@@ -7,8 +7,8 @@ import (
 	"io"
 	"io/ioutil"
 	"math"
-	"sync"
 	"strconv"
+	"sync"
 )
 
 //
@@ -44,7 +44,7 @@ type internalParsedJson struct {
 	ParsedJson
 	containing_scope_offset []uint64
 	isvalid                 bool
-	index_chan				chan indexChan
+	index_chan              chan indexChan
 }
 
 func (pj *internalParsedJson) initialize(size int) {

--- a/parsed_serialize.go
+++ b/parsed_serialize.go
@@ -391,7 +391,8 @@ func (s *serializer) compressStringsS2() error {
 	}
 	s.sBuf = s.sBuf[:mel]
 	s.sBuf[0] = blockTypeS2
-	_ = s2.Encode(s.sBuf[1:], s.stringBuf)
+	sbCopy := s2.Encode(s.sBuf[1:], s.stringBuf)
+	s.sBuf = s.sBuf[:len(sbCopy)+1]
 
 	return nil
 }

--- a/parsed_serialize.go
+++ b/parsed_serialize.go
@@ -1,0 +1,304 @@
+package simdjson
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	"github.com/klauspost/compress/fse"
+	"github.com/klauspost/compress/huff0"
+	"github.com/klauspost/compress/s2"
+)
+
+type serializer struct {
+	tComp   fse.Scratch
+	sComp   huff0.Scratch
+	strings map[string]uint32
+	// Old -> new offset
+	stringsMap map[uint32]uint32
+	stringBuf  []byte
+
+	// Compressed strings
+	sBuf []byte
+	// Uncompressed tags
+	tagsBuf []byte
+	// Values
+	valuesBuf     []byte
+	valuesCompBuf []byte
+}
+
+func (s *serializer) Serialize(dst []byte, pj ParsedJson) ([]byte, error) {
+	// Header: Version byte
+	// Strings:
+	// - Varint: Compressed bytes total.
+	//  Compressed Blocks:
+	//     - Varint: Block compressed bytes
+	//     - Block type:
+	//     		0: uncompressed, rest is data.
+	//     		1: RLE, data: 1 value, varuint: length
+	//     		2: huff0 with table.
+	// 	   - block data.
+	// 	   Ends when total is reached.
+	// Varuint: Tape length, Unique Elements
+	// Tags: FSE compressed block
+	// - Byte type:
+	// 		- 0: Uncompressed.
+	// 		- 1: RLE: 1 value, varuint: length
+	// 		- 2: FSE compressed with table.
+	// - Varuint compressed size.
+	// - Table + data.
+	// Values:
+	// - Varint total size.
+	// 	 - Null, BoolTrue/BoolFalse: Nothing added.
+	//   - TagRoot:Absolute Varuint offset.
+	//   - TagObjectStart, TagArrayStart: varuint: Offset - Current offset
+	//   - TagObjectEnd, TagArrayEnd: varuint: Current offset - Offset
+	//   - TagInteger: Varint
+	//   - TagUint: Varuint
+	//   - TagFloat: 64 bits
+	// 	 - TagString: Varuint offset
+
+	// Index strings
+	err := s.indexStrings(pj.Strings)
+	if err != nil {
+		return nil, err
+	}
+	err = s.compressStrings()
+	if err != nil {
+		return nil, err
+	}
+	//fmt.Println("strings dedupe:", len(pj.Strings), "->", len(s.stringBuf))
+
+	// Pessimistically allocate for maximum possible size.
+	if cap(s.tagsBuf) <= len(pj.Tape) {
+		s.tagsBuf = make([]byte, len(pj.Tape)+1)
+	}
+	s.tagsBuf = s.tagsBuf[:len(pj.Tape)+1]
+	if cap(s.valuesBuf) < len(pj.Tape)*binary.MaxVarintLen64 {
+		s.valuesBuf = make([]byte, len(pj.Tape)*binary.MaxVarintLen64)
+	}
+	s.valuesBuf = s.valuesBuf[:0]
+	off := 0
+	tagsOff := 0
+	var tmp [binary.MaxVarintLen64]byte
+	for off < len(pj.Tape) {
+		entry := pj.Tape[off]
+		ntype := Tag(entry >> 56)
+		payload := entry & JSONVALUEMASK
+		off++
+		switch ntype {
+		case TagString:
+			sOffset, ok := s.stringsMap[uint32(payload)]
+			if !ok {
+				return nil, fmt.Errorf("unable to find string at offset %d", payload)
+			}
+			s.tagsBuf[tagsOff] = symbolString
+			n := binary.PutUvarint(tmp[:], uint64(sOffset))
+			s.valuesBuf = append(s.valuesBuf, tmp[:n]...)
+		case TagUint:
+			s.tagsBuf[tagsOff] = symbolUint
+			n := binary.PutUvarint(tmp[:], pj.Tape[off])
+			s.valuesBuf = append(s.valuesBuf, tmp[:n]...)
+			off++
+		case TagInteger:
+			s.tagsBuf[tagsOff] = symbolInteger
+			n := binary.PutVarint(tmp[:], int64(pj.Tape[off]))
+			s.valuesBuf = append(s.valuesBuf, tmp[:n]...)
+			off++
+		case TagFloat:
+			s.tagsBuf[tagsOff] = symbolFloat
+			binary.LittleEndian.PutUint64(tmp[:8], pj.Tape[off])
+			s.valuesBuf = append(s.valuesBuf, tmp[:8]...)
+			off++
+		case TagNull:
+			s.tagsBuf[tagsOff] = symbolNull
+		case TagBoolTrue:
+			s.tagsBuf[tagsOff] = symbolBoolTrue
+		case TagBoolFalse:
+			s.tagsBuf[tagsOff] = symbolBoolFalse
+		case TagObjectStart:
+			s.tagsBuf[tagsOff] = symbolObjectStart
+			n := binary.PutUvarint(tmp[:], payload-uint64(off))
+			s.valuesBuf = append(s.valuesBuf, tmp[:n]...)
+		case TagObjectEnd:
+			s.tagsBuf[tagsOff] = symbolObjectEnd
+			n := binary.PutUvarint(tmp[:], uint64(off)-payload)
+			s.valuesBuf = append(s.valuesBuf, tmp[:n]...)
+		case TagArrayStart:
+			s.tagsBuf[tagsOff] = symbolArrayStart
+			n := binary.PutUvarint(tmp[:], payload-uint64(off))
+			s.valuesBuf = append(s.valuesBuf, tmp[:n]...)
+		case TagArrayEnd:
+			s.tagsBuf[tagsOff] = symbolArrayEnd
+			n := binary.PutUvarint(tmp[:], uint64(off)-payload)
+			s.valuesBuf = append(s.valuesBuf, tmp[:n]...)
+		case TagRoot:
+			s.tagsBuf[tagsOff] = symbolRoot
+			n := binary.PutUvarint(tmp[:], payload)
+			s.valuesBuf = append(s.valuesBuf, tmp[:n]...)
+
+		default:
+			return nil, fmt.Errorf("unknown tag: %v", ntype)
+		}
+		tagsOff++
+	}
+
+	s.tagsBuf[tagsOff] = symbolEnd
+	s.tagsBuf = s.tagsBuf[:tagsOff]
+	s.tComp.MaxSymbolValue = symbolEnd + 1
+	s.tComp.TableLog = 7
+	var compHeader [binary.MaxVarintLen64 + 2]byte
+	var compHeaderLen int
+	comp, err := fse.Compress(s.tagsBuf, &s.tComp)
+	switch err {
+	case fse.ErrUseRLE:
+		comp = nil
+		compHeader[0] = 1
+		compHeader[1] = s.tagsBuf[0]
+		compHeaderLen = 2 + binary.PutUvarint(compHeader[2:], uint64(len(s.tagsBuf)))
+	case fse.ErrIncompressible:
+		comp = s.tagsBuf
+		compHeader[0] = 0
+		compHeaderLen = 1 + binary.PutUvarint(compHeader[1:], uint64(len(s.tagsBuf)))
+	case nil:
+		compHeader[0] = 2
+		compHeaderLen = 1 + binary.PutUvarint(compHeader[1:], uint64(len(comp)))
+	default:
+		return nil, err
+	}
+
+	// S2 compress values
+	s.valuesCompBuf = s2.Encode(s.valuesCompBuf, s.valuesBuf)
+
+	// Version
+	dst = append(dst, 1)
+	// Size
+	// TODO: Doesn't include the varints
+	n := binary.PutUvarint(tmp[:], uint64(len(s.sBuf)+len(comp)+len(s.valuesBuf)+compHeaderLen))
+	dst = append(dst, tmp[:n]...)
+
+	// Strings
+	n = binary.PutUvarint(tmp[:], uint64(len(s.sBuf)))
+	dst = append(dst, tmp[:n]...)
+	dst = append(dst, s.sBuf...)
+
+	// Tags
+	dst = append(dst, compHeader[:compHeaderLen]...)
+	if len(comp) > 0 {
+		dst = append(dst, comp...)
+	}
+
+	// Values
+	n = binary.PutUvarint(tmp[:], uint64(len(s.valuesCompBuf)))
+	dst = append(dst, tmp[:n]...)
+	dst = append(dst, s.valuesCompBuf...)
+	fmt.Println("strings:", len(pj.Strings), "->", len(s.sBuf), "tags:", len(s.tagsBuf), "->", len(comp), "values:", len(s.valuesBuf), "->", len(s.valuesCompBuf), "Total:", len(pj.Strings)+len(pj.Tape)*8, "->", len(dst))
+
+	return dst, nil
+}
+
+const (
+	symbolString = iota
+	symbolInteger
+	symbolUint
+	symbolFloat
+	symbolNull
+	symbolBoolTrue
+	symbolBoolFalse
+	symbolObjectStart
+	symbolObjectEnd
+	symbolArrayStart
+	symbolArrayEnd
+	symbolRoot
+	symbolEnd
+)
+
+// indexStrings will deduplicate strings and populate
+// strings, stringsMap and stringBuf.
+func (s *serializer) indexStrings(sb []byte) error {
+	if s.strings == nil {
+		s.strings = make(map[string]uint32, 100)
+	} else {
+		for k := range s.strings {
+			delete(s.strings, k)
+		}
+	}
+	if s.stringsMap == nil {
+		s.stringsMap = make(map[uint32]uint32, 100)
+	} else {
+		for k := range s.stringsMap {
+			delete(s.stringsMap, k)
+		}
+	}
+	if cap(s.stringBuf) == 0 {
+		s.stringBuf = make([]byte, 0, len(sb))
+	}
+	s.stringBuf = s.stringBuf[:0]
+	var srcOff, dstOff uint32
+	for int(srcOff) < len(sb) {
+		length := binary.LittleEndian.Uint32(sb[srcOff : srcOff+4])
+		value := sb[srcOff+4 : srcOff+4+length]
+		off, ok := s.strings[string(value)]
+		if ok {
+			s.stringsMap[srcOff] = off
+			srcOff += 5 + length
+			continue
+		}
+		// New value, add to dst
+		s.stringsMap[srcOff] = dstOff
+		s.stringBuf = append(s.stringBuf, byte(dstOff), byte(dstOff>>8), byte(dstOff>>16), byte(dstOff>>24))
+		s.stringBuf = append(s.stringBuf, value...)
+		s.stringBuf = append(s.stringBuf, 0)
+		s.strings[string(value)] = dstOff
+		srcOff += 5 + length
+		dstOff += 5 + length
+	}
+	return nil
+}
+
+const (
+	blockTypeUncompressed = 0
+	blockTypeRLE          = 1
+	blockTypeHuff0Table   = 2
+)
+
+func (s *serializer) compressStrings() error {
+	if cap(s.sBuf) < len(s.stringBuf) {
+		s.sBuf = make([]byte, len(s.stringBuf))
+	}
+
+	const stringBlockSize = 64 << 10
+	compress := s.stringBuf
+	s.sBuf = s.sBuf[:0]
+	s.sComp.Reuse = huff0.ReusePolicyNone
+	var tmp [binary.MaxVarintLen64]byte
+	var tmp2 [binary.MaxVarintLen64]byte
+	for len(compress) > 0 {
+		todo := compress
+		if len(todo) > stringBlockSize {
+			todo = todo[:stringBlockSize]
+		}
+		compress = compress[len(todo):]
+		out, _, err := huff0.Compress1X(todo, &s.sComp)
+		switch err {
+		case nil:
+			n := binary.PutUvarint(tmp[:], uint64(len(out)+1))
+			s.sBuf = append(s.sBuf, tmp[:n]...)
+			s.sBuf = append(s.sBuf, blockTypeHuff0Table)
+			s.sBuf = append(s.sBuf, out...)
+		case huff0.ErrUseRLE:
+			n := binary.PutUvarint(tmp[:], uint64(len(todo)))
+			n2 := binary.PutUvarint(tmp2[:], uint64(n+2))
+			s.sBuf = append(s.sBuf, tmp2[:n2]...)
+			s.sBuf = append(s.sBuf, blockTypeRLE, todo[0])
+			s.sBuf = append(s.sBuf, tmp[:n]...)
+		case huff0.ErrIncompressible:
+			n := binary.PutUvarint(tmp[:], uint64(len(todo)+1))
+			s.sBuf = append(s.sBuf, tmp[:n]...)
+			s.sBuf = append(s.sBuf, blockTypeUncompressed)
+			s.sBuf = append(s.sBuf, todo...)
+		default:
+			return err
+		}
+	}
+	return nil
+}

--- a/parsed_serialize_test.go
+++ b/parsed_serialize_test.go
@@ -10,7 +10,6 @@ func BenchmarkSerialize(b *testing.B) {
 		var s serializer
 		b.Run(tt.name, func(b *testing.B) {
 			tap, sb, org := loadCompressed(b, tt.name)
-
 			pj, err := LoadTape(bytes.NewBuffer(tap), bytes.NewBuffer(sb))
 			if err != nil {
 				b.Fatal(err)
@@ -19,9 +18,11 @@ func BenchmarkSerialize(b *testing.B) {
 			if err != nil {
 				b.Fatal(err)
 			}
-			b.Log(len(org), "(JSON) ->", len(output), "(Serialized)", 100*float64(len(output))/float64(len(org)), "%")
+			if false {
+				b.Log(len(org), "Full dedupe (JSON) ->", len(output), "(Serialized)", 100*float64(len(output))/float64(len(org)), "%")
+			}
 			//_ = ioutil.WriteFile(filepath.Join("testdata", tt.name+".compressed"), output, os.ModePerm)
-			b.SetBytes(int64(len(output)))
+			b.SetBytes(int64(len(org)))
 			b.ReportAllocs()
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
@@ -29,7 +30,6 @@ func BenchmarkSerialize(b *testing.B) {
 				if err != nil {
 					b.Fatal(err)
 				}
-				break
 			}
 		})
 	}

--- a/parsed_serialize_test.go
+++ b/parsed_serialize_test.go
@@ -1,0 +1,36 @@
+package simdjson
+
+import (
+	"bytes"
+	"testing"
+)
+
+func BenchmarkSerialize(b *testing.B) {
+	for _, tt := range testCases {
+		var s serializer
+		b.Run(tt.name, func(b *testing.B) {
+			tap, sb, org := loadCompressed(b, tt.name)
+
+			pj, err := LoadTape(bytes.NewBuffer(tap), bytes.NewBuffer(sb))
+			if err != nil {
+				b.Fatal(err)
+			}
+			output, err := s.Serialize(nil, *pj)
+			if err != nil {
+				b.Fatal(err)
+			}
+			b.Log(len(org), "(JSON) ->", len(output), "(Serialized)", 100*float64(len(output))/float64(len(org)), "%")
+			//_ = ioutil.WriteFile(filepath.Join("testdata", tt.name+".compressed"), output, os.ModePerm)
+			b.SetBytes(int64(len(output)))
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				output, err = s.Serialize(output[:0], *pj)
+				if err != nil {
+					b.Fatal(err)
+				}
+				break
+			}
+		})
+	}
+}

--- a/parsed_serialize_test.go
+++ b/parsed_serialize_test.go
@@ -19,7 +19,7 @@ func BenchmarkSerialize(b *testing.B) {
 				b.Fatal(err)
 			}
 			if false {
-				b.Log(len(org), "Full dedupe (JSON) ->", len(output), "(Serialized)", 100*float64(len(output))/float64(len(org)), "%")
+				b.Log(len(org), "(JSON) ->", len(output), "(Serialized)", 100*float64(len(output))/float64(len(org)), "%")
 			}
 			//_ = ioutil.WriteFile(filepath.Join("testdata", tt.name+".compressed"), output, os.ModePerm)
 			b.SetBytes(int64(len(org)))


### PR DESCRIPTION
Serialize and lightly compress parsed data.

Strings are deduplicated and S2 compressed.
Tags are FSE entropy compressed
Values have compression based on value type and S2 block (LZ77) compressed.

* `strings: 103409 -> 21407 tags: 7070 -> 1006 values: 13735 -> 8603 Total: 159985 -> 31028` compression of the separate elements and total compared to memory use.
* `127275 Full dedupe (JSON) -> 26704 (Serialized) 20.981339618935376 %`. Compressed size vs original JSON with full string deduplication
* `127275 Fast dedupe (JSON) -> 26713 (Serialized) 20.988410921233548 %`. Compressed size vs original JSON with approximate string deduplication.
* `No Dedupe: 127275 (JSON) -> 39338 (Serialized) 30.90787664505991 %` Compressed size with string deduplication disabled.

```
BenchmarkSerialize/apache_builds-12
strings: 103409 -> 17092 tags: 7070 -> 1006 values: 14203 -> 8687 Total: 159985 -> 26797
127275 Full dedupe (JSON) -> 26704 (Serialized) 20.981339618935376 %
127275 Fast dedupe (JSON) -> 26713 (Serialized) 20.988410921233548 %
No Dedupe: 127275 (JSON) -> 39338 (Serialized) 30.90787664505991 %

BenchmarkSerialize/canada-12
strings: strings: 150 -> 137 tags: 223238 -> 43143 values: 1001404 -> 745788 Total: 2675062 -> 789081
2251051 Full dedupe (JSON) -> 789080 (Serialized) 35.05384818025003 %
2251051 Fast dedupe (JSON) -> 789080 (Serialized) 35.05384818025003 %
No Dedupe: 2251051 (JSON) -> 789072 (Serialized) 35.05349279070088 %

BenchmarkSerialize/citm_catalog-12
strings: 354399 -> 6007 tags: 85037 -> 27271 values: 167279 -> 13596 Total: 1149831 -> 46886
1727204 Full dedupe (JSON) -> 46926 (Serialized) 2.7168765241395922 %
1727204 Fast dedupe (JSON) -> 46895 (Serialized) 2.7150817158830107 %
No Dedupe: 1727204 (JSON) -> 179256 (Serialized) 10.378391898119736 %

BenchmarkSerialize/github_events-12
strings: 55233 -> 12357 tags: 2528 -> 459 values: 4875 -> 4171 Total: 76649 -> 16998
65132 Full dedupe (JSON) -> 17003 (Serialized) 26.105447399127925 %
65132 Fast dedupe (JSON) -> 17061 (Serialized) 26.19449732850212 %
No Dedupe: 65132 (JSON) -> 20425 (Serialized) 31.359393232205367 %

BenchmarkSerialize/gsoc-2018-12
strings: 3116455 -> 681343 tags: 41716 -> 4591 values: 83545 -> 37933 Total: 3450183 -> 723880
3327831 Full dedupe (JSON) -> 680458 (Serialized) 20.44749267616054 %
3327831 Fast dedupe (JSON) -> 696588 (Serialized) 20.93219277060644 %
No Dedupe: 3327831 (JSON) -> 1056666 (Serialized) 31.752393676241372 %

BenchmarkSerialize/instruments-12
strings: 104205 -> 1500 tags: 14795 -> 3644 values: 22289 -> 2817 Total: 262045 -> 7972
220346 Full dedupe (JSON) -> 7971 (Serialized) 3.6174924890853477 %
220346 Fast dedupe (JSON) -> 8630 (Serialized) 3.9165675800786035 %
No Dedupe: 220346 (JSON) -> 34649 (Serialized) 15.724814609750121 %

BenchmarkSerialize/numbers-12
strings: 0 -> 2 tags: 10005 -> 38 values: 80018 -> 80025 Total: 160048 -> 80075
150124 Full dedupe (JSON) -> 80074 (Serialized) 53.33857344595135 %
150124 Fast dedupe (JSON) -> 80074 (Serialized) 53.33857344595135 %
No Dedupe: 150124 (JSON) -> 80074 (Serialized) 53.33857344595135 %

BenchmarkSerialize/marine_ik-12
strings: 318249 -> 1557 tags: 359565 -> 102570 values: 1271330 -> 796665 Total: 5156169 -> 900805
2983466 Full dedupe (JSON) -> 900804 (Serialized) 30.19320481614337 %
2983466 Fast dedupe (JSON) -> 900804 (Serialized) 30.19320481614337 %
No Dedupe: 2983466 (JSON) -> 965779 (Serialized) 32.3710409302469 %

BenchmarkSerialize/mesh-12
strings: 147 -> 138 tags: 80252 -> 14760 values: 354298 -> 254823 Total: 1226267 -> 269733
723597 Full dedupe (JSON) -> 269732 (Serialized) 37.27655034501249 %
723597 Fast dedupe (JSON) -> 269732 (Serialized) 37.27655034501249 %
No Dedupe: 723597 (JSON) -> 269732 (Serialized) 37.27655034501249 %

BenchmarkSerialize/mesh.pretty-12
strings: 147 -> 136 tags: 80252 -> 14760 values: 354298 -> 237821 Total: 1226267 -> 252729
1577353 Full dedupe (JSON) -> 252728 (Serialized) 16.022285436424188 %
1577353 Fast dedupe (JSON) -> 252728 (Serialized) 16.022285436424188 %
No Dedupe: 1577353 (JSON) -> 252728 (Serialized) 16.022285436424188 %

BenchmarkSerialize/twitterescaped-12
strings: 458412 -> 45077 tags: 29575 -> 7731 values: 48752 -> 17912 Total: 711884 -> 70733
562408 Full dedupe (JSON) -> 67380 (Serialized) 11.980626164634927 %
562408 Fast dedupe (JSON) -> 67657 (Serialized) 12.029878664599366 %
No Dedupe: 562408 (JSON) -> 126026 (Serialized) 22.40828722208788 %

BenchmarkSerialize/twitter-12               	
strings: 458412 -> 45077 tags: 29575 -> 7731 values: 48752 -> 17912 Total: 711884 -> 70733
631514 Full dedupe (JSON) -> 67380 (Serialized) 10.669597190244398 %
631514 Fast dedupe (JSON) -> 67657 (Serialized) 10.713460034140178 %
No Dedupe: 631514 (JSON) -> 126026 (Serialized) 19.95616882602761 %

BenchmarkSerialize/random-12
strings: 499068 -> 58994 tags: 49013 -> 10388 values: 85753 -> 52855 Total: 931188 -> 122250
510476 Full dedupe (JSON) -> 123247 (Serialized) 24.14354445654644 %
510476 Fast dedupe (JSON) -> 121899 (Serialized) 23.879477193834774 %
No Dedupe: 510476 (JSON) -> 220970 (Serialized) 43.28704973397378 %

BenchmarkSerialize/update-center-12
strings: 576996 -> 149393 tags: 35283 -> 5709 values: 73302 -> 55750 Total: 859260 -> 210865
533178 Full dedupe (JSON) -> 207271 (Serialized) 38.87463473736726 %
533178 Fast dedupe (JSON) -> 208743 (Serialized) 39.15071514578621 %
No Dedupe: 533178 (JSON) -> 279215 (Serialized) 52.36806469884354 %
```

De-duplication looses a lot of compression, but it is also the slowest part. See below.