### PR TITLE
Add concurrent NDJSON processing

### DIFF
--- a/simdjson_test.go
+++ b/simdjson_test.go
@@ -612,13 +612,13 @@ break"]`,
 			wantErr: true,
 		},
 		{
-			name: "invalid-json-not-detected-issue-24",
-			js: `"{\"\":[],\"\":[5\x00]}"`,
+			name:    "invalid-json-not-detected-issue-24",
+			js:      `"{\"\":[],\"\":[5\x00]}"`,
 			wantErr: true,
 		},
 		{
-			name: "missing-invalid-character-issue-25",
-			js: `{"":"\_000"}`,
+			name:    "missing-invalid-character-issue-25",
+			js:      `{"":"\_000"}`,
 			wantErr: true,
 		},
 	}


### PR DESCRIPTION
Informal test, 6 core laptop:

S3 Select Query: `select sum(CAST(fare_amount as float)) from s3object`
Input: `nyc-taxi-data-10M.json`

No SIMD (multithreaded):  35.055 s
SIMD (singlethreaded - old code):  32.004 s
SIMD (multithreaded - this PR):  19.880 s

S3 Select Query: `select sum(score) from s3object`
Input: `RC_2012-01`

No SIMD (multithreaded):  25.444 s
SIMD (singlethreaded - old code):   28.116 s
SIMD (multithreaded - this PR):   19.963 s

It does crash on a regular basis due to #44 though.
